### PR TITLE
Fix learnset bug with duplicate moves

### DIFF
--- a/moveset.py
+++ b/moveset.py
@@ -28,7 +28,10 @@ class Moveset(list):
 
 def get_default_moveset(learnset: list, level: int) -> Moveset:
     '''Returns the 4 most recently learned moves for a pokemon of this level'''
-    moveset = [move.move for move in learnset if move.level <= level]
-    if len(moveset) > 4:
-        return Moveset(moveset[-4:])
+    moveset = []
+    for move in learnset:
+        if move.level <= level and move.move not in moveset:
+            if len(moveset) == 4:
+                moveset.pop(0)
+            moveset.append(move.move)
     return Moveset(moveset)


### PR DESCRIPTION
Explanation: Some pokemons have a move in their level 1 learnset, then learn this move again later. This has to be ignored when the mon already has the move. For example currently rival's [pidgeotto](https://bulbapedia.bulbagarden.net/wiki/Pidgeotto_(Pok%C3%A9mon)/Generation_I_learnset#By_leveling_up) shows 2 sand-attacks. You can't just remove duplicates though, as there are [sometimes](https://bulbapedia.bulbagarden.net/wiki/Victreebel_(Pok%C3%A9mon)/Generation_I_learnset#By_leveling_up) enough moves to erase the level 1 move before learning it again.